### PR TITLE
Document and implement local PDF email attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This is a production-ready SaaS Starter Kit for developers who want to build and
 
 - ✅ Built-in login/auth with NextAuth  
 - ✅ Forgot password + magic link login  
-- ✅ Email notifications via Resend.com  
+- ✅ Email notifications via Resend.com (with PDF invoice attachments)  
 - ✅ Stripe billing (upgrade/cancel plan)  
 - ✅ File uploads to DigitalOcean Spaces  
 - ✅ PostgreSQL via Prisma ORM  
@@ -230,6 +230,15 @@ The basic version of SeaNotes is now set up locally on your computer! You can st
 By default, email functionality is disabled for local development, allowing you to sign up and log in without setting up an email provider. However, features like password reset and magic links won't work until email is configured.
 
 This starter kit comes with [Resend](https://resend.com) integration built-in. All you need to do is get your API key and a verified sender email address from Resend, and add them to your `.env` file.
+
+### Email Features
+
+The Resend integration supports:
+- **Transactional emails**: Signup verification, password reset, magic links
+- **Invoice generation with PDF attachments**: Automatically generates and attaches PDF invoices to billing emails
+- **React-based email templates**: Consistent styling using React Email components
+
+> **Note on Attachments**: The email service uses local (in-memory) attachments. PDFs and other files are generated on-the-fly as Buffer objects and attached directly to emails. Files are not saved to disk or fetched from external URLs. This approach ensures fast, secure attachment handling without requiring external storage.
 
 ### Steps:
 

--- a/application/src/app/api/billing/generate-invoice/route.tsx
+++ b/application/src/app/api/billing/generate-invoice/route.tsx
@@ -131,6 +131,8 @@ async function generateInvoiceHandler(
     const generatedInvoice = await invoiceService.generateInvoice(invoiceData);
     
     // Generate PDF for email attachment
+    // Note: PDF is generated in-memory as a Buffer (local attachment approach)
+    // The PDF is not saved to disk or uploaded to external storage
     let pdfBuffer: Buffer | null = null;
     let pdfFilename: string | null = null;
     
@@ -138,6 +140,7 @@ async function generateInvoiceHandler(
       const pdfAvailable = await pdfService.isAvailable();
       
       if (pdfAvailable) {
+        // Generate PDF in memory using Puppeteer
         pdfBuffer = await pdfService.generateInvoicePDF(generatedInvoice.html);
         pdfFilename = `invoice-${invoiceData.invoiceNumber}-${userDetails.name.replace(/\s+/g, '-')}.pdf`;
       }
@@ -150,12 +153,14 @@ async function generateInvoiceHandler(
     
     if (emailService.isEmailEnabled()) {
       // Prepare email attachments
+      // Using local attachment approach: PDF Buffer is attached directly to the email
+      // The attachment is sent as base64-encoded content, not as a remote URL
       const attachments = [];
       
       if (pdfBuffer && pdfFilename) {
         attachments.push({
           filename: pdfFilename,
-          content: pdfBuffer,
+          content: pdfBuffer,  // In-memory Buffer object (local attachment)
           contentType: 'application/pdf'
         });
       }

--- a/application/src/services/email/email.ts
+++ b/application/src/services/email/email.ts
@@ -1,5 +1,14 @@
 import { ServiceConfigStatus, ConfigurableService } from '../status/serviceConfigStatus';
 
+/**
+ * Email attachment interface for local (in-memory) file attachments.
+ * This implementation uses the local attachment approach where file content 
+ * is sent directly as Buffer objects, not remote URLs.
+ * 
+ * @property filename - Name of the file as it will appear in the email
+ * @property content - In-memory file content as Buffer (local attachment)
+ * @property contentType - MIME type of the attachment (e.g., 'application/pdf')
+ */
 export interface EmailAttachment {
   filename: string;
   content: Buffer;

--- a/application/src/services/email/resendEmailService.ts
+++ b/application/src/services/email/resendEmailService.ts
@@ -58,6 +58,17 @@ export class ResendEmailService extends EmailService {
     return serverConfig.enableEmailIntegration;
   }
 
+  /**
+   * Sends an email with React components as the body and optional attachments.
+   * 
+   * @param to - Recipient email address
+   * @param subject - Email subject line
+   * @param body - React component to render as email body
+   * @param attachments - Optional array of local file attachments (in-memory Buffers)
+   *                      Note: Uses local attachment approach - file content is sent directly as base64.
+   *                      Remote URL attachments are not supported.
+   * @throws Error if email client is not initialized or sending fails
+   */
   async sendReactEmail(
     to: string, 
     subject: string, 
@@ -90,10 +101,12 @@ export class ResendEmailService extends EmailService {
       };
 
       // Add attachments if provided
+      // Note: This implementation uses local attachments only (in-memory Buffers)
+      // Remote URL attachments are not currently supported
       if (attachments && attachments.length > 0) {
         emailData.attachments = attachments.map(attachment => ({
           filename: attachment.filename,
-          content: attachment.content.toString('base64'), // Convert Buffer to base64
+          content: attachment.content.toString('base64'), // Convert local Buffer to base64 for Resend API
           contentType: attachment.contentType,
         }));
       }


### PR DESCRIPTION
Updated documentation across email service to explicitly indicate that attachments are handled as in-memory Buffer objects, not remote URLs.

Added JSDoc comments, inline explanations, and README section to make the local attachment approach clear per Resend team feedback.