### PR TITLE
feat: Add Google Analytics and Tag Manager integration

### DIFF
--- a/application/env-example
+++ b/application/env-example
@@ -126,3 +126,14 @@ NEXT_PUBLIC_DIGITALOCEAN_GRADIENTAI_ENABLED=true
 # Controls the verbosity of application logs
 # Valid values: error, warn, info, debug
 # LOG_LEVEL=info
+
+# ====================
+# ANALYTICS (Google Analytics & Tag Manager)
+# ====================
+# Optional: Google Analytics and Tag Manager for tracking and marketing
+# When configured: Enables tracking and tag management on all pages
+# When not configured: No tracking occurs (privacy-first by default)
+# Get your Measurement ID from: https://analytics.google.com/
+# Get your GTM Container ID from: https://tagmanager.google.com/
+NEXT_PUBLIC_GA_MEASUREMENT_ID=
+NEXT_PUBLIC_GTM_ID=

--- a/application/src/app/layout.tsx
+++ b/application/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Geist, Geist_Mono, Roboto, Plus_Jakarta_Sans, Inter } from 'next/font/google';
 import { Providers } from 'context/Providers';
 import WithLoadingSpinner from 'components/Common/LoadingSpinner/LoadingSpinner';
+import GoogleAnalytics from 'components/Analytics/GoogleAnalytics';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -51,6 +52,7 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => (
       className={`${geistSans.variable} ${geistMono.variable}`}
       style={{ margin: 0, WebkitFontSmoothing: 'antialiased', MozOsxFontSmoothing: 'grayscale' }}
     >
+      <GoogleAnalytics />
       <Providers>
         <WithLoadingSpinner>{children}</WithLoadingSpinner>
       </Providers>

--- a/application/src/components/Analytics/GoogleAnalytics.tsx
+++ b/application/src/components/Analytics/GoogleAnalytics.tsx
@@ -1,0 +1,65 @@
+import Script from 'next/script';
+
+/**
+ * Google Analytics and Tag Manager component for tracking user interactions.
+ * Only loads when the respective environment variables are set.
+ * This ensures analytics is optional and privacy-first by default.
+ * 
+ * Environment variables:
+ * - NEXT_PUBLIC_GA_MEASUREMENT_ID: Google Analytics Measurement ID
+ * - NEXT_PUBLIC_GTM_ID: Google Tag Manager Container ID
+ * 
+ * @returns Google Analytics and GTM scripts or null if not configured
+ */
+export default function GoogleAnalytics() {
+  const gaId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+  const gtmId = process.env.NEXT_PUBLIC_GTM_ID;
+  
+  // Don't render anything if neither GA nor GTM is configured
+  if (!gaId && !gtmId) {
+    return null;
+  }
+  
+  return (
+    <>
+      {/* Google Tag Manager - should be as high as possible in head */}
+      {gtmId && (
+        <Script
+          id="google-tag-manager"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+              new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+              j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+              'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+              })(window,document,'script','dataLayer','${gtmId}');
+            `,
+          }}
+        />
+      )}
+      
+      {/* Google Analytics (gtag.js) */}
+      {gaId && (
+        <>
+          <Script
+            strategy="afterInteractive"
+            src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+          />
+          <Script
+            id="google-analytics"
+            strategy="afterInteractive"
+            dangerouslySetInnerHTML={{
+              __html: `
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${gaId}');
+              `,
+            }}
+          />
+        </>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Added privacy-first Google Analytics and Tag Manager integration
- Component only loads when environment variables are configured
- Supports both GA4 and GTM for comprehensive tracking capabilities

## Changes
- New `GoogleAnalytics` component in `src/components/Analytics/`
- Integration in root layout (`src/app/layout.tsx`)
- Documentation of environment variables in `env-example`

## Configuration
To enable analytics, add these environment variables:
`NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX`
`NEXT_PUBLIC_GTM_ID=GTM-XXXXXXX`

## Testing
1. Configure environment variables
2. Check browser DevTools Network tab for GA/GTM script loading
3. Verify `window.dataLayer` and `window.gtag` in console
4. Use Google Analytics DebugView for real-time event tracking

## Privacy & Security
- **Opt-in by default**: No tracking occurs without configuration
- **No hardcoded IDs**: All configuration through environment variables
- **Production ready**: Uses Next.js Script component with `afterInteractive` strategy